### PR TITLE
Security update tegen timing-attack

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ app.get('/api/stats', (req, res) => {
 });
 
 app.post('/updateorders', upload.single('image'), async (req, res) => {
-    if (!req.body || !req.file || !req.body.reason || !req.body.password || safeCompare(req.body.password, process.env.PASSWORD)) {
+    if (!req.body || !req.file || !req.body.reason || !req.body.password || !safeCompare(req.body.password, process.env.PASSWORD)) {
         res.send('Ongeldig wachtwoord!');
         fs.unlinkSync(req.file.path);
         return;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const getPixels = require('get-pixels');
 const multer = require('multer')
 const upload = multer({ dest: `${__dirname}/uploads/` });
 
+const safeCompare = require('safe-compare')
+
 const VALID_COLORS = ['#6D001A', '#BE0039', '#FF4500', '#FFA800', '#FFD635', '#FFF8B8', '#00A368', '#00CC78', '#7EED56', '#00756F', '#009EAA', '#00CCC0', '#2450A4', '#3690EA', '#51E9F4', '#493AC1', '#6A5CFF', '#94B3FF', '#811E9F', '#B44AC0', '#E4ABFF', '#DE107F', '#FF3881', '#FF99AA', '#6D482F', '#9C6926', '#FFB470', '#000000', '#515252', '#898D90', '#D4D7D9', '#FFFFFF'];
 
 var appData = {
@@ -45,8 +47,8 @@ app.get('/api/stats', (req, res) => {
 });
 
 app.post('/updateorders', upload.single('image'), async (req, res) => {
-    if (!req.body || !req.file || !req.body.reason || !req.body.password || req.body.password !== process.env.PASSWORD) {
-        res.send('Ongeldig wachtwoord!');
+    if (!req.body || !req.file || !req.body.reason || !req.body.password || safeCompare(req.body.password, process.env.PASSWORD)) {
+        res.status(401).send('Ongeldig wachtwoord!');
         fs.unlinkSync(req.file.path);
         return;
     }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ app.get('/api/stats', (req, res) => {
 
 app.post('/updateorders', upload.single('image'), async (req, res) => {
     if (!req.body || !req.file || !req.body.reason || !req.body.password || safeCompare(req.body.password, process.env.PASSWORD)) {
-        res.status(401).send('Ongeldig wachtwoord!');
+        res.send('Ongeldig wachtwoord!');
         fs.unlinkSync(req.file.path);
         return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "express.js": "^1.0.0",
         "get-pixels": "^3.3.3",
         "multer": "^1.4.4",
+        "safe-compare": "^1.1.4",
         "ws": "^8.5.0"
       }
     },
@@ -113,6 +114,25 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -949,6 +969,14 @@
         }
       ]
     },
+    "node_modules/safe-compare": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
+      "dependencies": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1285,6 +1313,25 @@
         "raw-body": "2.4.3",
         "type-is": "~1.6.18"
       }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -1957,6 +2004,14 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-compare": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
+      "requires": {
+        "buffer-alloc": "^1.2.0"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express.js": "^1.0.0",
     "get-pixels": "^3.3.3",
     "multer": "^1.4.4",
+    "safe-compare": "^1.1.4",
     "ws": "^8.5.0"
   }
 }


### PR DESCRIPTION
Een normale string comparison maakt het voor hackers mogelijk om het wachtwoord te raden gebaseerd op hoelang het duurt totdat ze een reactie krijgen. Door safe-compare te gebruiken wordt dit onmoglijk gemaakt.

[Timing attack](https://en.wikipedia.org/wiki/Timing_attack)
[Timing attacks in nodejs](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/)
[Link naar de package](https://www.npmjs.com/package/safe-compare)