### PR TITLE
Basic dark mode toggle

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -32,6 +32,26 @@
             image-rendering: optimize-contrast;
             -ms-interpolation-mode: nearest-neighbor;
         }
+
+        #theme-picker-icon {
+            position: fixed;
+            top: 5px;
+            right: 5px;
+            z-index: 10;
+        }
+
+        .dark-mode {
+            background-color: #212020 !important;
+            color: #fff;
+        }
+        .dark-mode .card {
+            background-color: #212020 !important;
+            color: #fff;
+        }
+        .dark-mode .list-group-item {
+            background-color: #212020 !important;
+            color: #fff;
+        }
     </style>
 
     <title>PlaceNL Commando</title>
@@ -57,6 +77,8 @@
             </ul>
         </div>
     </div>
+
+    <div id="theme-picker-icon">☀️</div>
 
     <a href="/update.html" class="text-muted text-decoration-none">order control</a>
 
@@ -97,6 +119,36 @@
 
         updateStats();
         setInterval(updateStats, 5000);
+
+        const THEME_STORAGE_KEY = "THEME_DARKMODE";
+        const themePickerIcon = document.getElementById('theme-picker-icon');
+
+        function isDarkMode() {
+            return localStorage.getItem(THEME_STORAGE_KEY) === "true";
+        }
+
+        function setDarkMode(darkMode) {
+            localStorage.setItem(THEME_STORAGE_KEY, darkMode);
+        }
+
+        function updateTheme() {
+            const darkMode = isDarkMode();
+            if(darkMode) {
+                themePickerIcon.innerHTML = "🌑";
+                document.body.classList.add("dark-mode");
+            } else {
+                themePickerIcon.innerHTML = "☀️";
+                document.body.classList.remove("dark-mode");
+            }
+        }
+
+        themePickerIcon.addEventListener('click', function() {
+            const darkMode = isDarkMode();
+            setDarkMode(!darkMode);
+
+            updateTheme();
+        });
+        updateTheme();
     </script>
 </body>
 

--- a/static/index.html
+++ b/static/index.html
@@ -124,7 +124,13 @@
         const themePickerIcon = document.getElementById('theme-picker-icon');
 
         function isDarkMode() {
-            return localStorage.getItem(THEME_STORAGE_KEY) === "true";
+            const storedValue = localStorage.getItem(THEME_STORAGE_KEY)
+            if(storedValue === null) {
+                // Check system theme to default to dark mode when prefered
+                return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            }
+            
+            return storedValue === "true";
         }
 
         function setDarkMode(darkMode) {


### PR DESCRIPTION
Thought this one seemed fitting for what a few people will be doing tonight :P 

Kept the code super basic as a quick and dirty solution. There should be a moon and sun emoji at the top right which can be clicked to add some standard dark background/light text CSS styles. Default is still light mode and changing it will save that option in localstorage so it goes back to dark mode on refresh etc.

Icon top right in light mode
![image](https://user-images.githubusercontent.com/7481136/161596401-e15fc647-3036-40c0-af3f-2e80d1d73bdc.png)

With dark mode enabled
![image](https://user-images.githubusercontent.com/7481136/161596520-5ec927ee-9ad8-4ada-8aa8-d1f8f9e11867.png)

Can easily tweak this styling/functionality wise obviously so let me know